### PR TITLE
Set Dependabot version strategy to "increase"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
       time: '08:00'
       timezone: Europe/Amsterdam
     open-pull-requests-limit: 99
+    # Tell Dependabot to increase the version in package.json and package-lock,
+    # instead of the default widen strategy.
+    # https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#versioning-strategy
+    versioning-strategy: increase


### PR DESCRIPTION
The `package.json` file specifies that this package is of the "library" type.

https://github.com/damymetzke/node-build-util/blob/d46cc89c3e3ef886e9debdc5e637b51872d4a18e/package.json#L6

By default Dependabot will widen the range of versions for a library type package, according to their [docs](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#versioning-strategy):
> For libraries, the range of versions is widened, for example: Bundler and Cargo.

We can override this behavior and tell Dependabot to increase both the `package.json` and `package-lock.json` versions.

Fixes #50

----

EDIT: Yep just tried this on my fork, and it now updates both `package.json` and `package-lock.json`. :+1: 