### PR TITLE
Check for GitHub action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,10 @@ updates:
     # instead of the default widen strategy.
     # https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#versioning-strategy
     versioning-strategy: increase
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: '08:00'
+      timezone: Europe/Amsterdam


### PR DESCRIPTION
## Changes:

- Let Dependabot check for GitHub action updates

## Context:

Right now you need to check for updates to this line manually:

https://github.com/damymetzke/node-build-util/blob/d9e07f7eccfe514a37ee49e5410de41b80841bc0/.github/workflows/eslint.yml#L22

After merging this pull request Dependabot will do the update checks for you, on the same schedule as the Node updates.