### PR TITLE
Capitalize nouns, add newline to end of file

### DIFF
--- a/documentation/md/node-build-util.md
+++ b/documentation/md/node-build-util.md
@@ -19,7 +19,7 @@ Do **not** use NBU for complex or performance dependent build systems.
 - Supply scripts for specific actions (rendering markdown, linting, etc.).
 - Make the process of creating a new project as fast and easy as possible.
 - Fully support and encourage the use of promises + async/await.
-- Stay as close to vanilla javascript/typescript as possible.
+- Stay as close to vanilla JavaScript/TypeScript as possible.
 
 ## Contains
 


### PR DESCRIPTION
JavaScript and TypeScript are nouns (words that are names), and therefore need the proper capitalization.
Having a newline at the end of the file is helpful when you add new lines of code later.